### PR TITLE
feat: add native tool calling support with dual-path adapter architecture

### DIFF
--- a/examples/doc_agent.py
+++ b/examples/doc_agent.py
@@ -1,0 +1,113 @@
+"""
+Documentation Analysis Agent with Qwen3
+
+ReactAgent using Qwen3 on localhost to analyze documentation files with file system tools.
+
+Tools:
+    - glob: Find files matching a pattern
+    - grep: Search for patterns within files
+    - read_file: Read file contents
+
+Usage:
+    1. Start local server: vllm serve Qwen3-0.6B-Sushi-Coder --host 0.0.0.0 --port 8000
+    2. Run: python examples/doc_agent.py
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from pathlib import Path
+
+from tinyagent import ReactAgent, tool
+
+
+@tool
+def read_file(file_path: str) -> str:
+    """Read the contents of a file.
+
+    Args:
+        file_path: Path to the file to read
+
+    Returns:
+        File contents as a string
+    """
+    path = Path(file_path)
+    if not path.exists():
+        return f"Error: File '{file_path}' does not exist"
+
+    if not path.is_file():
+        return f"Error: '{file_path}' is not a file"
+
+    try:
+        return path.read_text(encoding="utf-8")
+    except OSError as e:
+        return f"Error reading file: {e}"
+
+
+@tool
+def glob(pattern: str, path: str = ".") -> str:
+    """Find files matching a glob pattern.
+
+    Args:
+        pattern: Glob pattern (e.g., '*.py', '**/*.md')
+        path: Root directory to search (default: current directory)
+
+    Returns:
+        JSON string of matching file paths sorted by modification time
+    """
+    search_path = Path(path)
+    if not search_path.exists():
+        return json.dumps({"error": f"Path '{path}' does not exist"})
+
+    matches = sorted(search_path.glob(pattern), key=lambda p: p.stat().st_mtime, reverse=True)
+    return json.dumps([str(m) for m in matches])
+
+
+class LoggingReactAgent(ReactAgent):
+    """ReactAgent with clean logging output."""
+
+    async def _chat(self, temperature: float):
+        """Log messages and responses in a clean format."""
+        print("\n" + "─" * 70)
+        print("📤 TO MODEL")
+        print("─" * 70)
+
+        for msg in self._memory.to_list():
+            role = msg["role"].upper()
+            content = msg.get("content", "")
+            print(f"\n[{role}]")
+            if content:
+                print(content)
+            if "tool_calls" in msg:
+                print(f"[TOOL CALLS: {msg['tool_calls']}]")
+
+        print("\n" + "─" * 70)
+        print("📥 FROM MODEL")
+        print("─" * 70)
+
+        response = await super()._chat(temperature)
+
+        print(f"\n{response}")
+        print("─" * 70 + "\n")
+
+        return response
+
+
+async def main() -> None:
+    agent = LoggingReactAgent(
+        tools=[read_file, glob],
+        model="openai/gpt-4.1-mini",
+        max_tokens=4000,
+    )
+
+    result = await agent.run(
+        "Find all Python files in the tinyagent directory and read the first one to understand what it does.",
+        verbose=True,
+        max_steps=10,
+    )
+    print(f"Result: {result}")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/tinyagent/__init__.py
+++ b/tinyagent/__init__.py
@@ -37,6 +37,7 @@ Signals:
 Tools:
     tool                - Decorator to create tools (returns Tool)
     validate_tool_class - Validate a tool class
+    ToolCallingMode     - Tool calling adapter mode
 
 Types:
     FinalAnswer         - Final answer with metadata
@@ -67,6 +68,7 @@ from .core import (  # noqa: E402
     MultipleFinalAnswers,
     RunResult,
     StepLimitReached,
+    ToolCallingMode,
     ToolDefinitionError,
     tool,
 )
@@ -119,6 +121,7 @@ __all__ = [
     # Tools
     "tool",
     "validate_tool_class",
+    "ToolCallingMode",
     # Types
     "FinalAnswer",
     "RunResult",

--- a/tinyagent/core/__init__.py
+++ b/tinyagent/core/__init__.py
@@ -1,5 +1,6 @@
 """tinyagent.core package exports."""
 
+from .adapters import ToolCallingMode, get_adapter
 from .exceptions import InvalidFinalAnswer, MultipleFinalAnswers, StepLimitReached
 from .finalizer import Finalizer
 from .parsing import parse_json_response, strip_llm_wrappers
@@ -13,6 +14,8 @@ __all__ = [
     "StepLimitReached",
     "MultipleFinalAnswers",
     "InvalidFinalAnswer",
+    "ToolCallingMode",
+    "get_adapter",
     "Tool",
     "ToolDefinitionError",
     "tool",

--- a/tinyagent/core/adapters.py
+++ b/tinyagent/core/adapters.py
@@ -1,0 +1,389 @@
+"""
+tinyagent.core.adapters
+Tool calling adapter implementations and selection.
+"""
+
+from __future__ import annotations
+
+import inspect
+import json
+from dataclasses import dataclass
+from enum import Enum
+from typing import Any, Protocol, Sequence, get_type_hints
+
+from pydantic import BaseModel, ConfigDict, ValidationError, create_model
+
+from .parsing import parse_json_response
+from .registry import Tool
+from .schema import tool_to_json_schema
+
+__all__ = [
+    "ToolCallingMode",
+    "ToolCallingAdapter",
+    "ToolCallValidation",
+    "OpenAIStructuredAdapter",
+    "NativeToolAdapter",
+    "ValidatedAdapter",
+    "ParsedAdapter",
+    "get_adapter",
+]
+
+TOOL_KEY = "tool"
+ARGUMENTS_KEY = "arguments"
+ANSWER_KEY = "answer"
+SCRATCHPAD_KEY = "scratchpad"
+
+RESPONSE_FORMAT_KEY = "response_format"
+RESPONSE_TYPE_KEY = "type"
+JSON_SCHEMA_KEY = "json_schema"
+SCHEMA_KEY = "schema"
+STRICT_KEY = "strict"
+NAME_KEY = "name"
+
+RESPONSE_SCHEMA_NAME = "agent_response"
+RESPONSE_FORMAT_TYPE = "json_schema"
+
+DEFAULT_VALIDATION_RETRIES = 2
+VALIDATION_ERROR_PREFIX = "ArgValidationError: "
+
+STRUCTURED_MODEL_PREFIXES = ("gpt-4o", "gpt-4.1", "o1", "o3", "openai/gpt-oss")
+
+# Models that support native OpenAI-compatible tool calling
+NATIVE_TOOL_MODEL_PATTERNS = (
+    "gpt-3.5",
+    "gpt-4",
+    "claude",
+    "gemini",
+    "mistral",
+    "llama",
+    "qwen",
+    "deepseek",
+    "openai/",
+    "anthropic/",
+    "google/",
+    "meta-llama/",
+    "mistralai/",
+)
+
+
+class ToolCallingMode(Enum):
+    AUTO = "auto"
+    NATIVE = "native"
+    STRUCTURED = "structured"
+    VALIDATED = "validated"
+    PARSED = "parsed"
+
+
+@dataclass(frozen=True)
+class ToolCallValidation:
+    is_valid: bool
+    error_message: str | None = None
+    arguments: dict[str, Any] | None = None
+
+
+class ToolCallingAdapter(Protocol):
+    def format_request(
+        self, tools: Sequence[Tool], messages: Sequence[dict[str, str]]
+    ) -> dict[str, Any]:
+        """Return kwargs to add to a chat completion request."""
+
+    def extract_tool_call(self, response: Any) -> dict[str, Any] | None:
+        """Extract a tool call payload from an LLM response (str or ChatCompletion)."""
+
+    def validate_tool_call(
+        self, payload: dict[str, Any], tools_by_name: dict[str, Tool]
+    ) -> ToolCallValidation:
+        """Validate tool call arguments, returning normalized arguments when applicable."""
+
+    def format_assistant_message(self, response: Any) -> dict[str, Any]:
+        """Format assistant response for memory."""
+
+    def format_tool_result(
+        self, tool_call_id: str | None, result: str, is_error: bool
+    ) -> dict[str, Any]:
+        """Format tool result for memory."""
+
+
+class OpenAIStructuredAdapter:
+    def format_request(
+        self, tools: Sequence[Tool], messages: Sequence[dict[str, str]]
+    ) -> dict[str, Any]:
+        schema = self._build_combined_schema(tools)
+        response_schema = {
+            NAME_KEY: RESPONSE_SCHEMA_NAME,
+            STRICT_KEY: True,
+            SCHEMA_KEY: schema,
+        }
+        return {
+            RESPONSE_FORMAT_KEY: {
+                RESPONSE_TYPE_KEY: RESPONSE_FORMAT_TYPE,
+                JSON_SCHEMA_KEY: response_schema,
+            }
+        }
+
+    def extract_tool_call(self, response: Any) -> dict[str, Any] | None:
+        return _safe_json_loads(_extract_content(response))
+
+    def validate_tool_call(
+        self, payload: dict[str, Any], tools_by_name: dict[str, Tool]
+    ) -> ToolCallValidation:
+        return ToolCallValidation(is_valid=True)
+
+    def format_assistant_message(self, response: Any) -> dict[str, Any]:
+        return {"role": "assistant", "content": _extract_content(response)}
+
+    def format_tool_result(
+        self, tool_call_id: str | None, result: str, is_error: bool
+    ) -> dict[str, Any]:
+        prefix = "" if is_error else "Observation: "
+        return {"role": "user", "content": f"{prefix}{result}"}
+
+    def _build_combined_schema(self, tools: Sequence[Tool]) -> dict[str, Any]:
+        tool_variants = [self._tool_schema(tool) for tool in tools]
+        answer_schema = self._answer_schema()
+        scratchpad_schema = self._scratchpad_schema()
+        variants = [*tool_variants, answer_schema, scratchpad_schema]
+        return {"anyOf": variants}
+
+    def _tool_schema(self, tool: Tool) -> dict[str, Any]:
+        arguments_schema = tool_to_json_schema(tool)
+        properties = {
+            TOOL_KEY: {"enum": [tool.name]},
+            ARGUMENTS_KEY: arguments_schema,
+            SCRATCHPAD_KEY: {"type": "string"},
+        }
+        return {
+            "type": "object",
+            "properties": properties,
+            "required": [TOOL_KEY, ARGUMENTS_KEY],
+            "additionalProperties": False,
+        }
+
+    def _answer_schema(self) -> dict[str, Any]:
+        properties = {
+            ANSWER_KEY: {"type": "string"},
+            SCRATCHPAD_KEY: {"type": "string"},
+        }
+        return {
+            "type": "object",
+            "properties": properties,
+            "required": [ANSWER_KEY],
+            "additionalProperties": False,
+        }
+
+    def _scratchpad_schema(self) -> dict[str, Any]:
+        properties = {
+            SCRATCHPAD_KEY: {"type": "string"},
+        }
+        return {
+            "type": "object",
+            "properties": properties,
+            "required": [SCRATCHPAD_KEY],
+            "additionalProperties": False,
+        }
+
+
+class ValidatedAdapter:
+    max_retries: int = DEFAULT_VALIDATION_RETRIES
+
+    def format_request(
+        self, tools: Sequence[Tool], messages: Sequence[dict[str, str]]
+    ) -> dict[str, Any]:
+        return {}
+
+    def extract_tool_call(self, response: Any) -> dict[str, Any] | None:
+        return parse_json_response(_extract_content(response))
+
+    def validate_tool_call(
+        self, payload: dict[str, Any], tools_by_name: dict[str, Tool]
+    ) -> ToolCallValidation:
+        tool_name = payload.get(TOOL_KEY)
+        if not tool_name:
+            return ToolCallValidation(is_valid=True)
+
+        tool = tools_by_name.get(tool_name)
+        if tool is None:
+            return ToolCallValidation(is_valid=True)
+
+        raw_args = payload.get(ARGUMENTS_KEY, {})
+        args = _normalize_arguments(raw_args)
+        if args is None:
+            return ToolCallValidation(
+                is_valid=False,
+                error_message="Tool arguments must be a JSON object.",
+            )
+
+        args_model = _build_args_model(tool)
+        try:
+            validated_args = args_model.model_validate(args)
+        except ValidationError as exc:
+            error_message = f"{VALIDATION_ERROR_PREFIX}{exc}"
+            return ToolCallValidation(is_valid=False, error_message=error_message)
+
+        normalized_args = validated_args.model_dump()
+        return ToolCallValidation(is_valid=True, arguments=normalized_args)
+
+    def format_assistant_message(self, response: Any) -> dict[str, Any]:
+        return {"role": "assistant", "content": _extract_content(response)}
+
+    def format_tool_result(
+        self, tool_call_id: str | None, result: str, is_error: bool
+    ) -> dict[str, Any]:
+        prefix = "" if is_error else "Observation: "
+        return {"role": "user", "content": f"{prefix}{result}"}
+
+
+class ParsedAdapter:
+    def format_request(
+        self, tools: Sequence[Tool], messages: Sequence[dict[str, str]]
+    ) -> dict[str, Any]:
+        return {}
+
+    def extract_tool_call(self, response: Any) -> dict[str, Any] | None:
+        return parse_json_response(_extract_content(response))
+
+    def validate_tool_call(
+        self, payload: dict[str, Any], tools_by_name: dict[str, Tool]
+    ) -> ToolCallValidation:
+        return ToolCallValidation(is_valid=True)
+
+    def format_assistant_message(self, response: Any) -> dict[str, Any]:
+        return {"role": "assistant", "content": _extract_content(response)}
+
+    def format_tool_result(
+        self, tool_call_id: str | None, result: str, is_error: bool
+    ) -> dict[str, Any]:
+        prefix = "" if is_error else "Observation: "
+        return {"role": "user", "content": f"{prefix}{result}"}
+
+
+class NativeToolAdapter:
+    """Adapter for models with native OpenAI-compatible tool calling."""
+
+    # Store last tool_call_id for format_tool_result
+    _last_tool_call_id: str | None = None
+
+    def format_request(
+        self, tools: Sequence[Tool], messages: Sequence[dict[str, str]]
+    ) -> dict[str, Any]:
+        return {"tools": [self._to_openai_tool(t) for t in tools]}
+
+    def extract_tool_call(self, response: Any) -> dict[str, Any] | None:
+        message = response.choices[0].message
+
+        # Check for native tool calls first
+        if message.tool_calls:
+            tc = message.tool_calls[0]
+            self._last_tool_call_id = tc.id
+            args = _safe_json_loads(tc.function.arguments) or {}
+            return {TOOL_KEY: tc.function.name, ARGUMENTS_KEY: args}
+
+        # Fall back to content (for final answers)
+        self._last_tool_call_id = None
+        content = (message.content or "").strip()
+        if content:
+            return {ANSWER_KEY: content}
+
+        return None
+
+    def validate_tool_call(
+        self, payload: dict[str, Any], tools_by_name: dict[str, Tool]
+    ) -> ToolCallValidation:
+        return ToolCallValidation(is_valid=True)
+
+    def format_assistant_message(self, response: Any) -> dict[str, Any]:
+        message = response.choices[0].message
+        msg: dict[str, Any] = {"role": "assistant", "content": message.content}
+        if message.tool_calls:
+            msg["tool_calls"] = [
+                {
+                    "id": tc.id,
+                    "type": "function",
+                    "function": {"name": tc.function.name, "arguments": tc.function.arguments},
+                }
+                for tc in message.tool_calls
+            ]
+        return msg
+
+    def format_tool_result(
+        self, tool_call_id: str | None, result: str, is_error: bool
+    ) -> dict[str, Any]:
+        call_id = tool_call_id or self._last_tool_call_id or "unknown"
+        return {"role": "tool", "tool_call_id": call_id, "content": result}
+
+    def _to_openai_tool(self, tool: Tool) -> dict[str, Any]:
+        return {
+            "type": "function",
+            "function": {
+                "name": tool.name,
+                "description": tool.doc or "",
+                "parameters": tool.json_schema,
+            },
+        }
+
+
+def get_adapter(model: str, mode: ToolCallingMode = ToolCallingMode.AUTO) -> ToolCallingAdapter:
+    if mode == ToolCallingMode.AUTO:
+        if _supports_structured_outputs(model):
+            return OpenAIStructuredAdapter()
+        if _supports_native_tools(model):
+            return NativeToolAdapter()
+        return ValidatedAdapter()
+
+    if mode == ToolCallingMode.NATIVE:
+        return NativeToolAdapter()
+    if mode == ToolCallingMode.STRUCTURED:
+        return OpenAIStructuredAdapter()
+    if mode == ToolCallingMode.VALIDATED:
+        return ValidatedAdapter()
+    if mode == ToolCallingMode.PARSED:
+        return ParsedAdapter()
+
+    raise ValueError(f"Unsupported tool calling mode: {mode}")
+
+
+def _supports_structured_outputs(model: str) -> bool:
+    model_lower = model.lower()
+    return any(model_lower.startswith(prefix) for prefix in STRUCTURED_MODEL_PREFIXES)
+
+
+def _supports_native_tools(model: str) -> bool:
+    model_lower = model.lower()
+    return any(pattern in model_lower for pattern in NATIVE_TOOL_MODEL_PATTERNS)
+
+
+def _safe_json_loads(text: str) -> dict[str, Any] | None:
+    try:
+        return json.loads(text)
+    except json.JSONDecodeError:
+        return None
+
+
+def _extract_content(response: Any) -> str:
+    """Extract content string from response (handles both str and ChatCompletion)."""
+    if isinstance(response, str):
+        return response
+    # ChatCompletion object
+    return (response.choices[0].message.content or "").strip()
+
+
+def _normalize_arguments(value: Any) -> dict[str, Any] | None:
+    if value is None:
+        return {}
+    if not isinstance(value, dict):
+        return None
+    return value
+
+
+def _build_args_model(tool: Tool) -> type[BaseModel]:
+    hints = get_type_hints(tool.fn)
+    fields: dict[str, tuple[Any, Any]] = {}
+    empty_default = inspect._empty
+    for name, param in tool.signature.parameters.items():
+        param_type = hints.get(name, param.annotation)
+        default = param.default if param.default is not empty_default else ...
+        fields[name] = (param_type, default)
+
+    config = ConfigDict(extra="forbid")
+    model_name = f"{tool.name}Args"
+    return create_model(model_name, __config__=config, **fields)

--- a/tinyagent/core/memory.py
+++ b/tinyagent/core/memory.py
@@ -1,0 +1,39 @@
+"""
+tinyagent.core.memory
+Simple message-based memory for conversations.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+__all__ = ["Memory"]
+
+
+@dataclass
+class Memory:
+    """Simple message storage. Adapter controls format."""
+
+    messages: list[dict[str, Any]] = field(default_factory=list)
+
+    def add(self, message: dict[str, Any]) -> None:
+        self.messages.append(message)
+
+    def add_system(self, content: str) -> None:
+        self.add({"role": "system", "content": content})
+
+    def add_user(self, content: str) -> None:
+        self.add({"role": "user", "content": content})
+
+    def add_assistant(self, content: str) -> None:
+        self.add({"role": "assistant", "content": content})
+
+    def clear(self) -> None:
+        self.messages.clear()
+
+    def to_list(self) -> list[dict[str, Any]]:
+        return list(self.messages)
+
+    def __len__(self) -> int:
+        return len(self.messages)

--- a/tinyagent/core/schema.py
+++ b/tinyagent/core/schema.py
@@ -1,0 +1,171 @@
+"""
+tinyagent.core.schema
+JSON Schema utilities for tool calling.
+"""
+
+from __future__ import annotations
+
+import inspect
+from enum import Enum
+from typing import (
+    TYPE_CHECKING,
+    Annotated,
+    Any,
+    Literal,
+    Union,
+    get_args,
+    get_origin,
+    get_type_hints,
+)
+
+if TYPE_CHECKING:
+    from .registry import Tool
+
+__all__ = ["python_type_to_json_schema", "tool_to_json_schema"]
+
+TYPE_KEY = "type"
+PROPERTIES_KEY = "properties"
+REQUIRED_KEY = "required"
+ENUM_KEY = "enum"
+ITEMS_KEY = "items"
+ANY_OF_KEY = "anyOf"
+DESCRIPTION_KEY = "description"
+ADDITIONAL_PROPERTIES_KEY = "additionalProperties"
+DEFAULT_KEY = "default"
+
+OBJECT_TYPE = "object"
+ARRAY_TYPE = "array"
+STRING_TYPE = "string"
+INTEGER_TYPE = "integer"
+NUMBER_TYPE = "number"
+BOOLEAN_TYPE = "boolean"
+NULL_TYPE = "null"
+
+_NONE_TYPE = type(None)
+_ARRAY_ORIGINS = (list, set)
+
+
+def python_type_to_json_schema(python_type: Any) -> dict[str, Any]:
+    """Map Python types to JSON Schema fragments."""
+    if python_type in {Any, object}:
+        return {TYPE_KEY: OBJECT_TYPE}
+
+    origin = get_origin(python_type)
+    args = get_args(python_type)
+
+    if origin is not None:
+        if origin is Annotated:
+            return python_type_to_json_schema(args[0])
+        if origin is Literal:
+            return _literal_schema(args)
+        if origin is Union:
+            return _union_schema(args)
+        if origin is dict:
+            return _dict_schema(args)
+        if origin is tuple:
+            return _tuple_schema(args)
+        if origin in _ARRAY_ORIGINS:
+            return _array_schema(args)
+
+    if python_type is str:
+        return {TYPE_KEY: STRING_TYPE}
+    if python_type is bool:
+        return {TYPE_KEY: BOOLEAN_TYPE}
+    if python_type is int:
+        return {TYPE_KEY: INTEGER_TYPE}
+    if python_type is float:
+        return {TYPE_KEY: NUMBER_TYPE}
+    if python_type is _NONE_TYPE:
+        return {TYPE_KEY: NULL_TYPE}
+    if inspect.isclass(python_type) and issubclass(python_type, Enum):
+        return _enum_schema(python_type)
+
+    return {TYPE_KEY: OBJECT_TYPE}
+
+
+def tool_to_json_schema(tool: "Tool") -> dict[str, Any]:
+    """Convert a Tool signature to a JSON Schema for its arguments."""
+    signature = tool.signature
+    hints = get_type_hints(tool.fn)
+
+    properties: dict[str, Any] = {}
+    required: list[str] = []
+    empty_default = inspect._empty
+
+    for name, param in signature.parameters.items():
+        param_type = hints.get(name, param.annotation)
+        param_schema = python_type_to_json_schema(param_type)
+        if param.default is empty_default:
+            required.append(name)
+        else:
+            param_schema[DEFAULT_KEY] = param.default
+        properties[name] = param_schema
+
+    schema: dict[str, Any] = {
+        TYPE_KEY: OBJECT_TYPE,
+        PROPERTIES_KEY: properties,
+        ADDITIONAL_PROPERTIES_KEY: False,
+    }
+    if required:
+        schema[REQUIRED_KEY] = required
+    if tool.doc:
+        schema[DESCRIPTION_KEY] = tool.doc
+
+    return schema
+
+
+def _array_schema(args: tuple[Any, ...]) -> dict[str, Any]:
+    item_type = args[0] if args else Any
+    items_schema = python_type_to_json_schema(item_type)
+    return {TYPE_KEY: ARRAY_TYPE, ITEMS_KEY: items_schema}
+
+
+def _tuple_schema(args: tuple[Any, ...]) -> dict[str, Any]:
+    if not args:
+        return _array_schema(())
+    if len(args) == 2 and args[1] is Ellipsis:
+        return _array_schema((args[0],))
+
+    schemas = [python_type_to_json_schema(item) for item in args]
+    return {TYPE_KEY: ARRAY_TYPE, ITEMS_KEY: {ANY_OF_KEY: schemas}}
+
+
+def _dict_schema(args: tuple[Any, ...]) -> dict[str, Any]:
+    value_type = args[1] if len(args) == 2 else Any
+    value_schema = python_type_to_json_schema(value_type)
+    return {TYPE_KEY: OBJECT_TYPE, ADDITIONAL_PROPERTIES_KEY: value_schema}
+
+
+def _union_schema(args: tuple[Any, ...]) -> dict[str, Any]:
+    schemas = [python_type_to_json_schema(item) for item in args]
+    return {ANY_OF_KEY: schemas}
+
+
+def _literal_schema(args: tuple[Any, ...]) -> dict[str, Any]:
+    values = list(args)
+    schema: dict[str, Any] = {ENUM_KEY: values}
+    type_name = _literal_type_name(values)
+    if type_name is not None:
+        schema[TYPE_KEY] = type_name
+    return schema
+
+
+def _literal_type_name(values: list[Any]) -> str | None:
+    if not values:
+        return None
+
+    types = {type(value) for value in values}
+    if len(types) != 1:
+        return None
+
+    only_type = next(iter(types))
+    return python_type_to_json_schema(only_type).get(TYPE_KEY)
+
+
+def _enum_schema(enum_type: type[Enum]) -> dict[str, Any]:
+    values = [member.value for member in enum_type]
+    schema: dict[str, Any] = {ENUM_KEY: values}
+    type_name = _literal_type_name(values)
+    if type_name is not None:
+        schema[TYPE_KEY] = type_name
+    return schema


### PR DESCRIPTION
## Summary

- Add `NativeToolAdapter` for models with OpenAI-compatible tool calling (GPT, Claude, Gemini, Llama, Qwen, etc.)
- Simplify `Memory` to a dataclass - adapter owns the message format
- Adapters now handle `format_assistant_message()` and `format_tool_result()`
- `NativeToolAdapter` uses proper `role="tool"` with `tool_call_id`
- Prompt-based adapters (Validated, Parsed, Structured) unchanged
- ReactAgent simplified from 404 to 302 lines

## Problem

Models with native tool calling were failing because the message format was wrong:
- Assistant messages had string content instead of `tool_calls` array
- Tool results used `role="user"` instead of `role="tool"` with `tool_call_id`

This caused models to loop infinitely, not recognizing they'd already received tool results.

## Solution

Dual-path architecture where adapter controls message format:

| Adapter | Assistant Message | Tool Result |
|---------|------------------|-------------|
| NativeToolAdapter | `{role: "assistant", tool_calls: [...]}` | `{role: "tool", tool_call_id: "..."}` |
| Prompt-based | `{role: "assistant", content: "..."}` | `{role: "user", content: "Observation: ..."}` |

## Test plan

- [x] Run `examples/doc_agent.py` - completes successfully with native tool calling
- [x] Pre-commit hooks pass (ruff, mypy, bandit)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  - Added multiple tool-calling modes (auto, native, structured, validated, parsed) for flexible agent behavior.
  - Enhanced tool system with built-in argument validation and JSON schema support.
  - Introduced Memory class for improved message and conversation management.

* **Examples**
  - New documentation analysis agent example demonstrating library usage with logging capabilities.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->