### PR TITLE
feat: add GitHub Actions CI pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,83 @@
+name: CI
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  PYTHON_VERSION: "3.12"
+  CARGO_TERM_COLOR: always
+
+jobs:
+  lint:
+    name: Lint (ruff + mypy)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+
+      - name: Install dev dependencies
+        run: pip install -e ".[dev]" --no-build-isolation
+
+      - name: Ruff check
+        run: ruff check .
+
+      - name: Ruff format check
+        run: ruff format --check .
+
+      - name: Mypy
+        run: mypy .
+
+  test:
+    name: Test (Python ${{ matrix.python-version }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.10", "3.11", "3.12"]
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - uses: Swatinem/rust-cache@v2
+
+      - name: Install package with dev deps
+        run: pip install -e ".[dev]" --no-build-isolation
+
+      - name: Run tests
+        run: pytest tests/ -v
+
+  rust:
+    name: Rust (check + clippy + fmt)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: clippy, rustfmt
+
+      - uses: Swatinem/rust-cache@v2
+
+      - name: Cargo check
+        run: cargo check
+
+      - name: Clippy
+        run: cargo clippy -- -D warnings
+
+      - name: Rustfmt
+        run: cargo fmt --check


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/ci.yml` with three parallel CI jobs
- **lint**: ruff check, ruff format --check, mypy
- **test**: pytest across Python 3.10 / 3.11 / 3.12 (builds Rust extension via maturin)
- **rust**: cargo check, clippy (`-D warnings`), rustfmt --check
- Concurrency group cancels stale runs on the same ref
- Rust builds cached via `Swatinem/rust-cache`

## Test plan
- [ ] Verify CI triggers on this PR
- [ ] Confirm all three jobs pass (lint, test, rust)
- [ ] Verify concurrency cancellation works on re-push

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Established an automated continuous integration pipeline that validates code quality and runs tests across multiple Python versions for each code submission and pull request.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->