### PR TITLE
feat: support reasoning effort levels in alchemy provider

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -74,3 +74,8 @@ alchemy-rs/
 # Investigation artifacts
 data/
 memory-bank/
+
+# Example artifacts
+example_reasoning_output.jsonl
+examples/example_reasoning_output.json
+examples/example_reasoning_output.jsonl

--- a/bindings/alchemy_llm_py/Cargo.lock
+++ b/bindings/alchemy_llm_py/Cargo.lock
@@ -27,9 +27,9 @@ dependencies = [
 
 [[package]]
 name = "alchemy-llm"
-version = "0.1.2"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "756d2b8f1112515c536d59f6114f23a20f819927b03e49dfcd9d7c28410456f8"
+checksum = "e93dd09ebc45215c46d1a0a26d1b27b19accbf5a7657d77cfa4bbd7f233142a0"
 dependencies = [
  "async-trait",
  "base64",
@@ -50,7 +50,7 @@ dependencies = [
 
 [[package]]
 name = "alchemy_llm_py"
-version = "1.1.3"
+version = "1.1.5"
 dependencies = [
  "alchemy-llm",
  "futures",

--- a/examples/example_reasoning.py
+++ b/examples/example_reasoning.py
@@ -1,0 +1,44 @@
+"""Reasoning example for tinyagent using alchemy-llm's Rust implementation of
+OpenAI-compatible streaming completions."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from pathlib import Path
+
+from dotenv import load_dotenv
+
+from tinyagent import Agent, AgentOptions
+from tinyagent.alchemy_provider import OpenAICompatModel, stream_alchemy_openai_completions
+
+
+async def main() -> None:
+    load_dotenv()
+
+    model = OpenAICompatModel(
+        provider="openrouter",
+        id="deepseek/deepseek-r1",
+        base_url="https://openrouter.ai/api/v1/chat/completions",
+        headers={"X-title": "tinyagent reasoning example"},
+        reasoning=True,
+    )
+    agent = Agent(AgentOptions(stream_fn=stream_alchemy_openai_completions))
+    agent.set_system_prompt(
+        "You are a helpful assistant that can reason step by step. "
+        "Answer the question at the end after reasoning."
+    )
+    agent.set_model(model)
+
+    prompt = "Question: If I have 3 apples and I buy 2 more, how many apples do I have?"
+
+    assistant_message = await agent.prompt(prompt)
+
+    output_path = Path(__file__).parent / "example_reasoning_output.json"
+    with output_path.open("w", encoding="utf-8") as f:
+        json.dump(assistant_message, f, indent=2)
+        f.write("\n")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())


### PR DESCRIPTION
## Summary
- fix `E501` line-length violations in `examples/example_reasoning.py`
- convert the top-level module string into a wrapped docstring
- wrap the long system prompt string into two concatenated literals

## Validation
- `.venv/bin/pre-commit run --all-files`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Reasoning configuration now supports effort levels (minimal, low, medium, high, xhigh) in addition to boolean values for finer-grained control.
  * Added example script demonstrating reasoning workflow usage.

* **Tests**
  * Added test coverage for reasoning effort forwarding.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->