### PR TITLE
docs: centralize alchemy binding documentation

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -159,15 +159,15 @@ Cache breakpoints are automatically placed on user message content blocks so the
 
 ## Optional Binding: `tinyagent._alchemy`
 
-This repo keeps `tinyagent/alchemy_provider.py` as a compatibility adapter for the
-optional external `tinyagent._alchemy` extension. The binding source, build
-instructions, and low-level binding API now live in:
+The single source of truth for the Rust-backed alchemy integration is:
 
-- `https://github.com/tunahorse/tinyagent-alchemy`
+- [Alchemy Binding Integration](alchemy-binding.md)
 
-The compiled path is still useful when you want OpenAI-compatible streaming
-without routing through a separate proxy, but it is no longer bundled or built
-from this repository.
+In short:
+
+- the binding implementation lives in `https://github.com/tunahorse/tinyagent-alchemy`
+- this repo keeps `tinyagent/alchemy_provider.py` as the Python compatibility adapter
+- release wheels may stage a prebuilt `_alchemy` artifact into `tinyagent/`
 
 ### Using via TinyAgent
 
@@ -233,6 +233,7 @@ Smoke validation after installing the external binding:
 ## Documentation
 
 - [Architecture](ARCHITECTURE.md): System design and component interactions
+- [Alchemy Binding Integration](alchemy-binding.md): Single source of truth for where the Rust binding lives, how the Python/Rust flow works, and how packaged wheels include `_alchemy`
 - [API Reference](api/): Detailed module documentation
 - [Prompt Caching](api/caching.md): Cache breakpoints, cost savings, and provider requirements
 - [OpenAI-Compatible Endpoints](api/openai-compatible-endpoints.md): Using `OpenAICompatModel.base_url` with OpenRouter/OpenAI/Chutes-compatible backends

--- a/docs/alchemy-binding.md
+++ b/docs/alchemy-binding.md
@@ -1,0 +1,216 @@
+# Alchemy Binding Integration
+
+This document is the single source of truth for TinyAgent's optional Rust-backed
+alchemy integration.
+
+It answers:
+
+- where the binding lives
+- what remains in this repo
+- how runtime calls flow across the Python/Rust boundary
+- how release wheels can include a built binding artifact
+- which files and tests define the contract
+
+## Scope and ownership
+
+The Rust binding implementation is not maintained in this repository.
+
+The source of truth for the binding implementation, build steps, and low-level
+native API is:
+
+- `https://github.com/tunahorse/tinyagent-alchemy`
+
+This repository keeps only the Python-side compatibility layer and packaging
+glue that let TinyAgent use a prebuilt binding artifact.
+
+## What lives where
+
+### External repo
+
+Active ownership:
+
+- Rust binding implementation
+- native build instructions
+- low-level exported `_alchemy` module behavior
+
+Repo:
+
+- `https://github.com/tunahorse/tinyagent-alchemy`
+
+### This repo
+
+Python/package responsibilities:
+
+- `tinyagent/alchemy_provider.py`
+  - Python adapter for the optional `tinyagent._alchemy` module
+  - request serialization
+  - provider/api/base_url/api-key resolution
+  - streamed event validation
+  - final message usage-contract validation
+- `docs/releasing-alchemy-binding.md`
+  - release-wheel staging workflow for a prebuilt `_alchemy` binary
+- `tests/test_alchemy_provider.py`
+  - adapter behavior and import/runtime validation
+- `tests/test_usage_contracts.py`
+  - payload-forwarding and usage-contract validation
+
+## Runtime flow
+
+The runtime path is:
+
+`Agent -> stream_alchemy_openai_completions -> tinyagent._alchemy -> streamed events -> agent_loop -> Agent state/app`
+
+### 1. Agent configuration
+
+Applications opt into the binding-backed path by setting:
+
+- `AgentOptions(stream_fn=stream_alchemy_openai_completions)`
+- `OpenAICompatModel(...)`
+
+The app does not call the Rust binding directly in normal TinyAgent usage.
+
+### 2. Python resolves the binding module
+
+`tinyagent.alchemy_provider._get_alchemy_module()` imports, in order:
+
+1. `tinyagent._alchemy`
+2. `_alchemy`
+
+If neither import succeeds, TinyAgent raises a `RuntimeError` that points to the
+external binding repo.
+
+### 3. Python resolves request settings
+
+`stream_alchemy_openai_completions()` resolves and normalizes:
+
+- `provider`
+- `api`
+- `base_url`
+- `api_key`
+- optional model metadata such as `headers`, `reasoning`, `context_window`, and
+  `max_tokens`
+
+API selection rules:
+
+- explicit `model.api` wins after alias normalization
+- `provider in {"minimax", "minimax-cn"}` infers `minimax-completions`
+- all other providers infer `openai-completions`
+
+API key resolution order:
+
+1. `options.api_key`
+2. provider-specific env var fallback
+
+Supported env vars:
+
+- `OPENAI_API_KEY`
+- `OPENROUTER_API_KEY`
+- `MINIMAX_API_KEY`
+- `MINIMAX_CN_API_KEY`
+
+### 4. Python serializes the request
+
+The adapter builds three dict payloads and passes them over the Python/Rust
+boundary:
+
+- `model_dict`
+- `context_dict`
+- `options_dict`
+
+`context_dict` includes:
+
+- `system_prompt`
+- serialized `messages`
+- converted tool schemas
+
+### 5. Python calls the Rust entrypoint
+
+The adapter calls:
+
+`tinyagent._alchemy.openai_completions_stream(model_dict, context_dict, options_dict)`
+
+That returns a stream handle with:
+
+- `next_event()`
+- `result()`
+
+### 6. Python consumes the native stream
+
+`AlchemyStreamResponse` wraps the native handle and bridges it into TinyAgent's
+async streaming contract.
+
+Behavior:
+
+- `__anext__()` calls `next_event()` via `asyncio.to_thread(...)`
+- each returned event is validated as an `AssistantMessageEvent`
+- `result()` calls the native `result()` method via `asyncio.to_thread(...)`
+- the final assistant message is validated before being returned
+
+This means the path is real-time, but the event iterator is not a native async
+Rust stream exposed directly to Python. Python polls a blocking native method in
+a worker thread.
+
+### 7. TinyAgent continues with normal agent flow
+
+After provider events come back from the binding-backed stream:
+
+- `agent_loop` translates `AssistantMessageEvent` into `AgentEvent`
+- tool calls are executed by TinyAgent's normal tool-execution path
+- `Agent` updates state and forwards events to subscribers
+
+The rest of the framework does not need special Rust-aware logic.
+
+## Packaging and release flow
+
+This repo does not build the binding from source.
+
+If a release wheel should include `_alchemy`, the workflow is:
+
+1. build the binding in the external repo
+2. copy the built artifact into `tinyagent/`
+3. run `python3 scripts/check_release_binding.py --require-present`
+4. build the wheel
+5. verify the wheel contains `tinyagent/_alchemy...`
+
+Expected staged filenames include:
+
+- `tinyagent/_alchemy.abi3.so`
+- `tinyagent/_alchemy.<platform>.so`
+- `tinyagent/_alchemy.pyd`
+- `tinyagent/_alchemy.dylib`
+
+The full release procedure remains documented in:
+
+- [Shipping the `tinyagent._alchemy` Binding in Release Wheels](releasing-alchemy-binding.md)
+
+## Current limitations
+
+- only `openai-completions` and `minimax-completions` are dispatched
+- image blocks are not supported yet
+- streamed native events are consumed through blocking `next_event()` calls run
+  in a worker thread
+
+## Validation and enforcement
+
+Primary code and test anchors:
+
+- `tinyagent/alchemy_provider.py`
+- `tests/test_alchemy_provider.py`
+- `tests/test_usage_contracts.py`
+- `docs/harness/tool_call_types_harness.py`
+
+Useful validation commands:
+
+```bash
+uv run pytest tests/test_alchemy_provider.py tests/test_usage_contracts.py
+uv run python docs/harness/tool_call_types_harness.py
+```
+
+## Related docs
+
+- [Architecture](ARCHITECTURE.md)
+- [API reference index](api/README.md)
+- [Providers](api/providers.md)
+- [OpenAI-compatible endpoints](api/openai-compatible-endpoints.md)
+- [Usage semantics](api/usage-semantics.md)
+- [Shipping the `tinyagent._alchemy` Binding in Release Wheels](releasing-alchemy-binding.md)

--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -22,6 +22,7 @@ Complete API documentation for the tinyagent package.
 
 | Module | Description |
 |--------|-------------|
+| [../alchemy-binding](../alchemy-binding.md) | Single source of truth for the Rust-backed alchemy integration and Python/Rust runtime flow |
 | [providers](providers.md) | Optional alchemy binding adapter and Proxy providers |
 | [openai-compatible-endpoints](openai-compatible-endpoints.md) | Using `OpenAICompatModel.base_url` with OpenAI-compatible endpoints |
 | [usage-semantics](usage-semantics.md) | Canonical `usage` schema, field mapping, and precedence rules |

--- a/docs/api/providers.md
+++ b/docs/api/providers.md
@@ -2,6 +2,11 @@
 
 LLM provider implementations that satisfy the `StreamFn` protocol.
 
+For the complete Rust-binding story, including ownership, Python/Rust boundary
+flow, packaging, and validation anchors, use:
+
+- [Alchemy Binding Integration](../alchemy-binding.md)
+
 ## Alchemy Provider (Optional External Binding)
 
 TinyAgent keeps an OpenAI-compatible provider adapter in `alchemy_provider.py`.

--- a/docs/releasing-alchemy-binding.md
+++ b/docs/releasing-alchemy-binding.md
@@ -1,5 +1,10 @@
 # Shipping the `tinyagent._alchemy` Binding in Release Wheels
 
+For the complete binding overview, including runtime ownership and the
+Python/Rust request flow, use:
+
+- [Alchemy Binding Integration](alchemy-binding.md)
+
 This document captures the release task we completed to make `tiny-agent-os`
 ship the prebuilt `tinyagent._alchemy` binary again when a release wheel is
 built.


### PR DESCRIPTION
## Summary
- add a single source-of-truth doc for the optional Rust-backed alchemy integration
- document ownership, runtime Python/Rust flow, packaging flow, and validation anchors in one place
- update README/API/release docs to point back to the canonical page

## Testing
- pre-commit hooks triggered by `git commit`
- no code or runtime behavior changed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Improved and reorganized Alchemy binding documentation with a new dedicated guide for the Rust-backed integration, including runtime control flow, request handling, and packaging details.
  * Updated related documentation pages with references to the comprehensive binding overview.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->