### PR TITLE
[codex] document host-side tool loop controls

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -4,7 +4,7 @@ when_to_read:
   - When starting from the docs directory instead of the repo root
   - When looking for the main product overview inside docs
 summary: Docs-local entry point for TinyAgent overview, installation, and examples.
-last_updated: "2026-04-04"
+last_updated: "2026-06-21"
 ---
 
 # TinyAgent
@@ -145,7 +145,10 @@ return AgentToolResult(
 ```
 
 For host-level policies, `AgentOptions` also supports `before_tool_call`,
-`after_tool_call`, and `should_stop_after_turn` hooks.
+`after_tool_call`, and `should_stop_after_turn` hooks. Use these when the
+application needs to block unsafe tool calls, replace a tool result, or stop
+after a turn without aborting the stream. See
+[Tool Loop Controls](api/tool-loop-controls.md) for the full flow.
 
 ### Events
 
@@ -255,6 +258,7 @@ Smoke validation after installing a wheel with the binding:
 - [Architecture](ARCHITECTURE.md): System design and component interactions
 - [API Reference](api/): Detailed module documentation
 - [Prompt Caching](api/caching.md): Cache breakpoints, cost savings, and provider requirements
+- [Tool Loop Controls](api/tool-loop-controls.md): Terminal tool results and host hooks for clean loop termination
 - [OpenAI-Compatible Endpoints](api/openai-compatible-endpoints.md): Using `OpenAICompatModel.base_url` with OpenRouter/OpenAI/Chutes-compatible backends
 - [Usage Semantics](api/usage-semantics.md): Canonical `usage` schema across provider flows
 - [Harness Rules](../rules/README.md): ast-grep rules for the live tool-call harness

--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -4,7 +4,7 @@ when_to_read:
   - When navigating the API docs
   - When choosing which module reference to open next
 summary: Index of the TinyAgent API reference pages by module and feature area.
-last_updated: "2026-05-25"
+last_updated: "2026-06-21"
 ---
 
 # API Reference
@@ -25,6 +25,7 @@ Complete API documentation for the tinyagent package.
 | Module | Description |
 |--------|-------------|
 | [caching](caching.md) | Prompt caching for reduced cost and latency |
+| [tool-loop-controls](tool-loop-controls.md) | Terminal tool results and host-side loop-control hooks |
 | [usage-semantics](usage-semantics.md) | Canonical usage contract and token semantics for the built-in provider path |
 
 ## Providers

--- a/docs/api/tool-loop-controls.md
+++ b/docs/api/tool-loop-controls.md
@@ -1,0 +1,152 @@
+---
+title: Tool Loop Controls
+when_to_read:
+  - When a host needs to stop repeated tool-call loops
+  - When adding policy around tool execution
+  - When deciding between terminal tool results and host hooks
+summary: Guide to terminal tool results and host-side tool-loop control hooks.
+last_updated: "2026-06-21"
+---
+
+# Tool Loop Controls
+
+TinyAgent supports host-side controls for ending repeated tool-call loops without
+raising an abort or relying on an outer timeout. This guide documents the public
+surface added by PR #40, `[codex] add host-side tool loop controls`.
+
+Use these controls when the application can tell the next model turn is not
+useful, unsafe, or allowed by policy. The agent still emits the normal tool
+execution, message, turn, and agent end events, so consumers see a completed run
+instead of a cancelled stream.
+
+## Control Points
+
+| Control | Runs | Use when |
+|---------|------|----------|
+| `AgentToolResult(terminate=True)` | Inside a tool implementation | The tool itself knows the run should stop after this result |
+| `before_tool_call` | Before each tool executes | The host should block or replace a tool call before side effects happen |
+| `after_tool_call` | After each tool result is built, before events are emitted | The host should inspect, replace, mark error, or terminate based on the result |
+| `should_stop_after_turn` | After a turn completes | The host should decide whether another model turn is allowed |
+
+`terminate` is host-side metadata. It is excluded from `ToolResultMessage`
+serialization, so providers do not receive it as part of the LLM message payload.
+
+## Terminal Tool Results
+
+Return a terminal result when the tool has enough local context to end the run:
+
+```python
+from tinyagent import AgentToolResult, TextContent
+
+
+async def search(tool_call_id, args, signal, on_update):
+    if args["query"] in {"same query", "same query again"}:
+        return AgentToolResult(
+            content=[TextContent(text="Stopping after repeated search arguments.")],
+            details={"policy": "repeated-search"},
+            terminate=True,
+        )
+
+    return AgentToolResult(content=[TextContent(text="search result")])
+```
+
+The current tool batch still finishes and emits result events. The agent then
+emits `turn_end` and `agent_end` without asking the model for another turn.
+
+## Before Tool Call
+
+Use `before_tool_call` for host policy that should run before the tool's side
+effects:
+
+```python
+from tinyagent import Agent, AgentOptions, AgentToolResult, TextContent, ToolLoopControl
+
+
+async def before_tool_call(tool_call, tool, args):
+    if tool_call.name == "delete_file":
+        return ToolLoopControl(
+            result=AgentToolResult(
+                content=[TextContent(text="Blocked by host policy.")],
+                details={"policy": "no-delete-file"},
+            ),
+            is_error=True,
+            terminate=True,
+        )
+
+    return None
+
+
+agent = Agent(
+    AgentOptions(
+        stream_fn=stream_fn,
+        before_tool_call=before_tool_call,
+    )
+)
+```
+
+Returning `ToolLoopControl(result=...)` supplies the structured tool result and
+skips the tool execution. Returning `None` lets the tool run normally.
+
+## After Tool Call
+
+Use `after_tool_call` when the host needs to inspect or replace a completed tool
+result before subscribers see it:
+
+```python
+from tinyagent import AgentToolResult, TextContent, ToolLoopControl
+
+
+async def after_tool_call(tool_call, result_message):
+    if result_message.details.get("quota_exhausted"):
+        return ToolLoopControl(
+            result=AgentToolResult(
+                content=[TextContent(text="Quota exhausted. Stopping now.")],
+                details={"policy": "quota"},
+            ),
+            is_error=True,
+            terminate=True,
+        )
+
+    return None
+```
+
+The replacement result is emitted in the original tool-call order. Marking the
+control terminal prevents steering from being polled after that batch and stops
+the run after `turn_end`.
+
+## Stop After Turn
+
+Use `should_stop_after_turn` for policies that need the assistant message, all
+tool results from the turn, the current context, and any newly queued messages:
+
+```python
+async def should_stop_after_turn(message, tool_results, context, new_messages):
+    error_count = sum(result.is_error for result in tool_results)
+    return error_count >= 3
+
+
+agent = Agent(
+    AgentOptions(
+        stream_fn=stream_fn,
+        should_stop_after_turn=should_stop_after_turn,
+    )
+)
+```
+
+When the callback returns `True`, TinyAgent ends the run cleanly instead of
+starting another model turn.
+
+## Execution Semantics
+
+Tool execution remains parallel. `before_tool_call` runs for each extracted tool
+call, unblocked tools execute concurrently, and `after_tool_call` runs before
+final result events are emitted. Result messages are still emitted in the
+assistant's original tool-call order.
+
+A terminal result or hook does not cancel already-started tools in the same
+batch. It marks the batch terminal, preserves normal event ordering, skips
+post-batch steering, and ends the agent run before another LLM call.
+
+These controls live above provider streaming. They work the same way with the
+in-repo `tinyagent._alchemy` provider path, the proxy provider, or a custom
+`StreamFn`.


### PR DESCRIPTION
## Summary

- Add a dedicated API guide for host-side tool loop controls added in PR #40.
- Link the new guide from the docs README and API reference index.
- Clarify when to use terminal tool results, `before_tool_call`, `after_tool_call`, and `should_stop_after_turn`.

## Why

The recent tool loop controls update added public behavior that was only lightly surfaced in the existing docs. This gives host/application developers one place to understand the control points, event semantics, and provider-neutral behavior.

## Impact

Docs-only. No runtime, packaging, or test code changes.

## Validation

- `git diff --check`
- `bash scripts/check_markdown_frontmatter.sh`
- `uv run --group dev pre-commit run markdown-frontmatter-required --hook-stage pre-push --all-files`
- `python3 scripts/lint_debt.py`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive guide for Tool Loop Controls documenting host-side mechanisms to manage tool execution loops cleanly.
  * Expanded existing documentation with clearer explanations of tool control features and improved cross-reference links.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->